### PR TITLE
Button UI Template Component

### DIFF
--- a/hyades-front/src/components/common/Button.js
+++ b/hyades-front/src/components/common/Button.js
@@ -1,25 +1,27 @@
 import React from "react";
 import styled, { css } from "styled-components";
-import { Link } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import Palette from "../../lib/Palette";
 
 const buttonStyle = css`
   border: none;
   border-radius: 4px;
-  font-size: 1rem;
+  background: transparent;
+  font-size: 1.5rem;
   font-weight: bold;
-  padding: 0.25rem 1rem;
-  color: white;
+  letter-spacing: 2px;
+  color: ${({fontcolor}) => fontcolor ? fontcolor : "white"};
   outline: none;
   cursor: pointer;
+  transition: all 0.3s ease-in-out;
 
-  background: ${Palette.gray[8]};
-  &:hover {
-    background: ${Palette.gray[6]};
-  }
+  ${({hovercolor}) => !hovercolor && css`
+    border: ${({fontcolor}) => `2px solid ${fontcolor}`};
+    padding: 0.3rem 0.5rem 0.4rem 0.6rem;
+  `}
 
-  ${(props) =>
-    props.fullWidth &&
+  ${({fullWidth}) =>
+    fullWidth &&
     css`
       padding-top: 0.75rem;
       padding-bottom: 0.75rem;
@@ -27,14 +29,14 @@ const buttonStyle = css`
       font-size: 1.125rem;
     `}
 
-  ${(props) =>
-    props.cyan &&
-    css`
-      background: ${Palette.cyan[5]};
-      &:hover {
-        background: ${Palette.cyan[4]};
-      }
+  &:hover{
+    ${({hovercolor}) => hovercolor ? css`
+      color: ${({hovercolor}) => hovercolor};
+    ` : css`
+      background-color: ${({fontcolor}) => fontcolor};
+      color: white;
     `}
+  }
 
     &:disabled {
     background: ${Palette.gray[3]};
@@ -43,20 +45,15 @@ const buttonStyle = css`
   }
 `;
 
-const StyledButton = styled.button`
+const Button = styled.button.attrs(({to}) => ({
+  as : to && NavLink
+}))`
   ${buttonStyle}
+  ${({to}) => to && css`
+    &.active{
+      color: ${({hovercolor}) => hovercolor}
+    }
+  `}
 `;
-
-const StyledLink = styled(Link)`
-  ${buttonStyle}
-`;
-
-const Button = (props) => {
-  return props.to ? (
-    <StyledLink {...props} cyan={props.cyan ? 1 : 0} />
-  ) : (
-    <StyledButton {...props} />
-  );
-};
 
 export default Button;


### PR DESCRIPTION
## Button UI Component
두가지 유형: border 있는 버튼, 없는 버튼

1. border 없는 버튼: 기본 font color (fontcolor)와 hover 시 font color (hovercolor)를 props로 받으면 된다.
2. border 있는 버튼 : 경우의 수가 너무 많아서 한 가지 유형으로 제한했다. (아래 사진 참고) props로 기본 color (fontcolor)만 받으면 된다.
![image](https://user-images.githubusercontent.com/89760088/156520610-1e3108d2-3aaf-4c65-b54a-def6b683d09e.png)
기본 border 있는 버튼
![image](https://user-images.githubusercontent.com/89760088/156520652-5a8e4697-74d8-46d8-80d4-ccc5a0ec8880.png)
hover 상태

⇒ hovercolor가 버튼의 border 유뮤를 결정한다. props 중에 hovercolor가 있으면 border 없는 버튼이고, 없다면 border 있는 버튼이다.

** fontcolor와 hovercolor를 camelcase로 작성하니 에러가 발생해 소문자로 작성했습니다.


## 사용
1. common에서 Button 임포트
2. border 없는 버튼 : props - fontcolor (옵션, default: white), hovercolor (필수)
3. border 있는 버튼 : props - fontcolor (필수)  **절대 props로 hovercolor 전달하면 **안됩니다**.
4. 만약 버튼 스타일을 바꾸고 싶다면 style override 하면 된다.
5. Button Component에 마진이 없어서 마진을 적용해야 한다면 style override 하면 된다.
    ```jsx
    // Example
    // common/Header.js
    
    import Button from "./Button";
    
    // style override
    const NavButton = styled(Button)`
      margin-left: 3rem;
    `;
    ```